### PR TITLE
Fixed an "undefined" when reading ps from history and there isn't any…

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -139,7 +139,11 @@ class stateNode {
     node.timestamp = Date.now();
     node.initialized = true;
     try {
-      var prev_ts = node.history[0].ts || 0;
+      var prev_ts = 0;
+      if (node.history !== undefined &&
+		  node.history[0] !== undefined &&
+		  node.history[0].ts !== undefined)  // @colincoder Initially this is undefined so deal with it
+		prev_ts = node.history[0].ts;
       if (node.config.historyCount > 0 && node.timestamp-prev_ts >= parseInt(node.config.saveInterval, 10)) {
         node.history.splice(0,0,{val:node.value, ts:node.timestamp});
         node.trimHistory();


### PR DESCRIPTION
….  Happens on an initial attempt to write the state file and no state has yet been established.
Just found this issue when applying 1.6.0 to a new project.  The original code to see if `ts` was in the history fails because no history is yet defined.  I rewrote it to make sure all parents of `ts` were defined before attempting to use its value.
This is related to the recent improvement you made to allow file writing frequency to be controllable.
Typical error statements on NR startup:
```
9 Jan 15:41:08 - [error] [shared-state:Water] Error writing state file: /home/pi/.node-red/shared-state/Water
9 Jan 15:41:08 - [error] [shared-state:Water] TypeError: Cannot read property 'ts' of undefined
```
